### PR TITLE
Pin espressif32 to 6.13.0 to fix I2S driver conflict on boot

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:m5stack-atom]
-platform = espressif32
+platform = espressif32@6.13.0
 board = m5stack-atom
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
Fixes #3

## Problem

With an unpinned `platform = espressif32`, PlatformIO resolves to the
latest version (7.x+), which ships Arduino ESP32 core 3.x. That core
introduced a new I2S driver architecture that conflicts with the legacy
`driver/i2s.h` used by this firmware, causing an `abort()` on boot:

    CONFLICT! The new i2s driver can't work along with the legacy i2s driver

## Fix

Pin to `espressif32@6.13.0` — the latest stable release in the 6.x
series (Arduino core 2.0.17 / IDF 4.4.7). The legacy I2S driver is the
only driver in that core, so there is no conflict.